### PR TITLE
Fix displaying docstring in command --help

### DIFF
--- a/cli_app/app.py
+++ b/cli_app/app.py
@@ -39,7 +39,7 @@ class App:
     def parse_command_arguments(self, parser):
         subparsers = parser.add_subparsers(dest='command')
         for name, config in self.commands.items():
-            subparser = subparsers.add_parser(name, description=config['description'])
+            subparser = subparsers.add_parser(name, help=config['description'], description=config['description'])
             config['cls'].register_arguments(subparser)
 
     def run_command(self, name):

--- a/cli_app/app.py
+++ b/cli_app/app.py
@@ -39,7 +39,7 @@ class App:
     def parse_command_arguments(self, parser):
         subparsers = parser.add_subparsers(dest='command')
         for name, config in self.commands.items():
-            subparser = subparsers.add_parser(name, help=config['description'])
+            subparser = subparsers.add_parser(name, description=config['description'])
             config['cls'].register_arguments(subparser)
 
     def run_command(self, name):


### PR DESCRIPTION
Hi, thanks for sharing great project!
When I was using your lib i noticed this bug:
ArgumentParser object requires keyword argument `description` instead of `help` according to https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser
Now after this fix, when you type `<command_name> -h` also docstring from command class is printed.  
  
Later I also noticed that, when i replaced `help` kwarg with `description` kwarg the `<app_name> --help` broke. There wasn't info about commands.
So, finally instead of replacing arguments I added `description` kwarg and now the docstring is visible in both: app help and command help